### PR TITLE
[feat] Implemented getGroupExpenses

### DIFF
--- a/src/main/kotlin/com/madteam/plugins/Routing.kt
+++ b/src/main/kotlin/com/madteam/plugins/Routing.kt
@@ -31,5 +31,6 @@ fun Application.configureRouting(
         getGroupExpenseTypes()
         getCurrencies()
         createNewExpense()
+        getGroupExpenses()
     }
 }

--- a/src/main/kotlin/com/madteam/routes/ExpenseRoutes.kt
+++ b/src/main/kotlin/com/madteam/routes/ExpenseRoutes.kt
@@ -90,3 +90,23 @@ fun Route.createNewExpense(){
         }
     }
 }
+
+fun Route.getGroupExpenses(){
+    val expenseRepository = ExpenseRepository()
+
+    authenticate {
+        get("getGroupExpenses"){
+            val groupId = call.request.queryParameters["groupId"]?.toIntOrNull()
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "Missing or malformed groupId")
+
+            val groupExpenses = try {
+                expenseRepository.getGroupExpenses(groupId)
+            } catch (e: Exception) {
+                call.respond(HttpStatusCode.InternalServerError, "Error obtaining group expenses")
+                return@get
+            }
+
+            call.respond(HttpStatusCode.OK, groupExpenses)
+        }
+    }
+}


### PR DESCRIPTION
http://0.0.0.0:8080/getGroupExpenses?groupId=10
[
    {
        "id": 28,
        "expenseTitle": "lengua de fuego",
        "expenseDescription": "erupción del popocatequeyi",
        "totalAmount": 50.0,
        "expenseType": {
            "id": 13,
            "title": "Salvación del mundo",
            "icon": "emoji_animals_nature_comet",
            "group": 10
        },
        "createdDate": "2024-02-08 17:48:22",
        "groupId": 10,
        "currency": {
            "currency": "EUR",
            "name": "Euro",
            "symbol": "€"
        },
        "paymentMethod": "",
        "images": [
            ""
        ],
        "paidBy": [
            {
                "expenseId": 28,
                "memberId": 21,
                "amount": 50.0
            }
        ],
        "forWhom": [
            {
                "expenseId": 28,
                "memberId": 21,
                "amount": 12.5
            },
            {
                "expenseId": 28,
                "memberId": 22,
                "amount": 12.5
            },
            {
                "expenseId": 28,
                "memberId": 23,
                "amount": 12.5
            },
            {
                "expenseId": 28,
                "memberId": 24,
                "amount": 12.5
            }
        ]
    }
]